### PR TITLE
refactor: delete traceparent generation to Traefik gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,6 +220,11 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
       - "--accesslog=true"
+      - "--tracing=true"
+      - "--tracing.otlp=true"
+      - "--tracing.otlp.http=false"
+      - "--tracing.otlp.grpc.endpoint=tempo:4317"
+      - "--tracing.otlp.grpc.insecure=true"
     ports:
       - "80:80"
       - "8085:8080"

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,20 +1,6 @@
 import keycloak from "../auth/keycloak";
 import { CONFIG } from "../config";
 
-function randomHex(bytes: number): string {
-    const arr = new Uint8Array(bytes);
-    crypto.getRandomValues(arr);
-    return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
-}
-
-function buildTraceparent(): string {
-    const version = "00";
-    const traceId = randomHex(16);
-    const parentId = randomHex(8);
-    const flags = "01";
-    return `${version}-${traceId}-${parentId}-${flags}`;
-}
-
 export async function apiFetch<T = any>(
     endpoint: string, 
     options: RequestInit = {},
@@ -26,11 +12,6 @@ export async function apiFetch<T = any>(
         "Content-Type": "application/json",
         ...(options.headers as Record<string, string> || {}),
     };
-    headers["traceparent"] = buildTraceparent();
-    const traceState = (window as Window & { __TRACESTATE__?: string }).__TRACESTATE__;
-    if (traceState) {
-        headers["tracestate"] = traceState;
-    }
 
     if (requireAuth) {
         if (!keycloak.authenticated) {


### PR DESCRIPTION
- Remove manual buildTraceparent from api.ts.
- Clean up HTTP request headers in the frontend client.
- Update docker-compose.yml to enable native OpenTelemetry tracing on Traefik, pointing to the Grafana Tempo gRPC endpoint.