### PR TITLE
chore(game_service): configure websocket heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The system is designed as a distributed set of services:
 
 **Redis for State Management**: Since game rooms are highly volatile, Redis provides the sub-millisecond latency required to track game status.
 
+**WebSocket Connection Resilience**: To prevent resource leaks caused by silent client disconnections, the Game Service leverages native Uvicorn protocol-level heartbeats.
+
 **Horizontal Scalability**: The architecture is designed to scale horizontally. By combining Traefik’s load balancing with Redis Pub/Sub, the platform can handle increased loads by simply spinning up more service replicas without losing state consistency.
 
 **CI**: Automated pipeline via GitHub Actions that runs Linter and Unit Tests on every push, ensuring code quality and coverage for the backend.

--- a/backend/game_service/Dockerfile
+++ b/backend/game_service/Dockerfile
@@ -32,4 +32,4 @@ USER appuser
 
 EXPOSE 8002
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002", "--ws-ping-interval", "20", "--ws-ping-timeout", "5"]


### PR DESCRIPTION
- Add --ws-ping-interval and --ws-ping-timeout flags to the Uvicorn startup command in the Dockerfile.