### PR TITLE
feat(ai): add language support for quiz generation

### DIFF
--- a/backend/ai_service/app/prompts/registry/quiz_generator.yaml
+++ b/backend/ai_service/app/prompts/registry/quiz_generator.yaml
@@ -1,15 +1,16 @@
 meta:
   name: "quiz_generator"
-  version: "1.1"
+  version: "1.2"
   description: "Prompt for generating structured quizzes"
 
 system_prompt: |
   You are an assistant specialized in creating educational and interactive quizzes.
-  Your task is to create a high-quality quiz strictly based on the provided parameters.
+  Your task is to create a high-quality quiz strictly based on the provided parameters and in the requested language.
   
   CRITICAL STRUCTURE CONSTRAINTS:
   1. Each question MUST have exactly 4 options.
-  4. The 'correct_answer_index' MUST be an integer between 0 and 3, corresponding to the correct string in the 'options' array.
+  2. The 'correct_answer_index' MUST be an integer between 0 and 3, corresponding to the correct string in the 'options' array.
+  3. The entire output (title, question stems, and options) MUST be written completely in the language specified by the user.
   
   QUALITY & ITEM WRITING RULES:
   - NO BINARY OR LAZY OPTIONS: Do not use "True/False", "Yes/No", "None of the above", or "All of the above". 
@@ -21,7 +22,7 @@ system_prompt: |
   - 'medium': Application and analysis. Requires the user to solve a scenario or differentiate between two similar concepts.
   - 'hard': Evaluation and synthesis. Focus on subtle edge cases, complex anti-patterns, or multi-step logical reasoning.
 
-  FEW-SHOT EXAMPLE (Topic: Python, Difficulty: medium):
+  FEW-SHOT EXAMPLE (Topic: Python, Difficulty: medium, Language: English):
   {{
     "quiz_title": "Python Concept",
     "questions": [
@@ -42,3 +43,4 @@ user_template: |
   Generate a quiz with exactly {count} questions.
   Topic: "{topic}"
   Difficulty: {difficulty}
+  Language: {language}

--- a/backend/ai_service/app/schemas/generation.py
+++ b/backend/ai_service/app/schemas/generation.py
@@ -16,6 +16,10 @@ class QuizGenerateRequest(BaseModel):
         default="medium",
         description="Difficulty level (easy, medium, hard)"
     )
+    language: str = Field(
+        default="English",
+        description="The language of the quiz"
+    )
 
 class QuestionFields(BaseModel):
     question_text: str = Field(..., description="The text of the question")

--- a/backend/ai_service/app/services/quiz_generator_service.py
+++ b/backend/ai_service/app/services/quiz_generator_service.py
@@ -20,7 +20,7 @@ class QuizGeneratorService:
         prompt_template = self.prompt_manager.get("quiz_generator")
 
         system_content = prompt_template.system_prompt
-        user_content = prompt_template.user_template.format(topic=request.topic, count=request.num_questions, difficulty=request.difficulty)
+        user_content = prompt_template.user_template.format(topic=request.topic, count=request.num_questions, difficulty=request.difficulty, language=request.language)
 
         return [
             {"role": "system", "content": system_content},

--- a/frontend/src/components/generateAI/AIConfigForm.tsx
+++ b/frontend/src/components/generateAI/AIConfigForm.tsx
@@ -5,9 +5,11 @@ interface Props {
     topic: string;
     numQuestions: number;
     difficulty: string;
+    language: string;
     onTopicChange: (val: string) => void;
     onNumQuestionsChange: (val: number) => void;
     onDifficultyChange: (val: string) => void;
+    onLanguageChange: (val: string) => void;
     onSubmit: () => void;
     onCancel: () => void;
 }
@@ -16,9 +18,11 @@ export function AIConfigForm({
     topic,
     numQuestions,
     difficulty,
+    language,
     onTopicChange,
     onNumQuestionsChange,
     onDifficultyChange,
+    onLanguageChange,
     onSubmit,
     onCancel
 }: Props) {
@@ -58,6 +62,24 @@ export function AIConfigForm({
                         <option value="easy">Easy</option>
                         <option value="medium">Medium</option>
                         <option value="hard">Hard</option>
+                    </select>
+                </section>
+
+                <section className="mq-form-section flex-1">
+                    <label className="mq-label">Language</label>
+                    <select
+                        className="mq-input-select"
+                        value={language}
+                        onChange={(e) => onLanguageChange(e.target.value)}
+                    >
+                        <option value="English">English</option>
+                        <option value="Spanish">Spanish</option>
+                        <option value="French">French</option>
+                        <option value="German">German</option>
+                        <option value="Italian">Italian</option>
+                        <option value="Portoguese">Portoguese</option>
+                        <option value="Chinese">Chinese</option>
+                        <option value="Japanese">Japanese</option>
                     </select>
                 </section>
             </div>

--- a/frontend/src/hooks/useGenerateAI.ts
+++ b/frontend/src/hooks/useGenerateAI.ts
@@ -26,6 +26,7 @@ export function useGenerateAI() {
     const [topic, setTopic] = useState<string>("");
     const [numQuestions, setNumQuestions] = useState<number>(5);
     const [difficulty, setDifficulty] = useState<string>("medium");
+    const [language, setLanguage] = useState<string>("English");
 
     const [loading, setLoading] = useState<boolean>(false);
     const [error, setError] = useState<string | null>(null);
@@ -35,6 +36,7 @@ export function useGenerateAI() {
         setTopic,
         setNumQuestions,
         setDifficulty,
+        setLanguage,
 
         generate: async() => {
             if (!topic.trim()) {
@@ -51,7 +53,8 @@ export function useGenerateAI() {
                     body: JSON.stringify({
                         topic,
                         num_questions: numQuestions,
-                        difficulty
+                        difficulty,
+                        language
                     }),
                 }, true);
 
@@ -143,6 +146,7 @@ export function useGenerateAI() {
             topic,
             numQuestions,
             difficulty,
+            language,
             loading,
             error,
             previewQuiz,

--- a/frontend/src/pages/GenerateAI.tsx
+++ b/frontend/src/pages/GenerateAI.tsx
@@ -39,9 +39,11 @@ export default function GenerateAI() {
             topic={state.topic}
             numQuestions={state.numQuestions}
             difficulty={state.difficulty}
+            language={state.language}
             onTopicChange={actions.setTopic}
             onNumQuestionsChange={actions.setNumQuestions}
             onDifficultyChange={actions.setDifficulty}
+            onLanguageChange={actions.setLanguage}
             onSubmit={actions.generate}
             onCancel={actions.goHome}
           />


### PR DESCRIPTION
- Update backend generation endpoints to accept and pass a language field
- Modify AI system prompt to enforce output in the requested language
- Add a language dropdown selector to the frontend configuration form