### PR TITLE
refactor(frontend): integrate Lucide Crown icon

### DIFF
--- a/frontend/src/components/room/LeaderboardView.tsx
+++ b/frontend/src/components/room/LeaderboardView.tsx
@@ -1,4 +1,5 @@
 import "../../styles/room/Leaderboard.css";
+import { Crown } from "lucide-react";
 
 interface LeaderboardEntry {
     name: string;
@@ -16,7 +17,7 @@ export function LeaderboardView({ leaderboard, isFinal }: LeaderboardViewProps) 
     return (
         <div className="mq-leaderboard-container">
             <h2 className="mq-leaderboard-header">
-                {isFinal ? "🏆 Final Results" : "📊 Leaderboard"}
+                {isFinal ? "Final Results" : "Leaderboard"}
             </h2>
 
             <div className="mq-podium-section">
@@ -35,7 +36,9 @@ export function LeaderboardView({ leaderboard, isFinal }: LeaderboardViewProps) 
                 {/* 1st Place */}
                 {leaderboard[0] && (
                     <div className="mq-podium-spot first">
-                        <div className="mq-podium-avatar">👑</div>
+                        <div className="mq-podium-avatar">
+                            <Crown size={28} className="mq-crown-icon" />
+                        </div>
                         <div className="mq-podium-name">{leaderboard[0].name}</div>
                         <div className="mq-podium-pillar">
                             <span className="mq-podium-score">{leaderboard[0].score}</span>

--- a/frontend/src/styles/room/Leaderboard.css
+++ b/frontend/src/styles/room/Leaderboard.css
@@ -43,6 +43,10 @@
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);
 }
 
+.mq-crown-icon {
+  color: #f59e0b;
+}
+
 .mq-podium-name {
   font-size: 0.9rem;
   font-weight: 700;


### PR DESCRIPTION
- Use Lucide Crown component for first place podium spot
- Clean up unused leaderboard header icons and styles