### PR TITLE
refactor(CI): pin ruff version in CI workflow

### DIFF
--- a/.github/workflows/python-service-ci.yml
+++ b/.github/workflows/python-service-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Ruff
         run: |
             python -m pip install --upgrade pip
-            pip install ruff
+            pip install ruff==0.15.22
 
       - name: Run lint
         run: ruff check backend/${{ inputs.service }} 


### PR DESCRIPTION
- Specify ruff version in python-service-ci.yml so the workflow installs a fixed linter version.