### PR TITLE
refactor(game-service): atomically transition rooms when starting quizzes

### DIFF
--- a/backend/game_service/app/services/quiz_engine.py
+++ b/backend/game_service/app/services/quiz_engine.py
@@ -14,9 +14,8 @@ ANSWER_REVEAL_DURATION = 4
 
 class QuizEngine:
     """Orchestrates the state, timing, and score calculations of a quiz game loop."""
-    def __init__(self, room_id: str, lock_key: str, redis_client: RedisClient, events_map: Dict[str, asyncio.Event]):
+    def __init__(self, room_id: str, redis_client: RedisClient, events_map: Dict[str, asyncio.Event]):
         self.room_id = room_id
-        self.lock_key = lock_key
         self._redis = redis_client
         self._events_map = events_map
 
@@ -28,12 +27,6 @@ class QuizEngine:
             if not questions:
                 logger.warning("No questions found for room", room_id=self.room_id)
                 return
-
-            # Initialize room state as started before entering the question loop.
-            await self._redis.update_room_status(
-                self.room_id,
-                status=RoomStatus.STARTED,
-            )
 
             for idx, question in enumerate(questions):
                 is_last = idx == len(questions) - 1

--- a/backend/game_service/app/services/redis/redis_client.py
+++ b/backend/game_service/app/services/redis/redis_client.py
@@ -1,6 +1,5 @@
 import redis.asyncio as redis
 import json
-import uuid
 import time
 from app.schemas.multiplayer import Room, RoomAnswer, Question, RoomStatus
 from app.models.multiplayer import Player, LeaderboardEntry
@@ -20,8 +19,8 @@ DEFAULT_LEADERBOARD_LIMIT = 5
 class RedisClient:
     def __init__(self):
         self.redis = redis.Redis.from_url(config.REDIS_URL, decode_responses=True)
-        self._locks: dict[str, str] = {}
         self._create_room_script = self._load_script("create_room.lua")
+        self._start_quiz_script = self._load_script("start_quiz.lua")
 
     def _load_script(self, filename: str):
         script_path = SCRIPTS_DIR / filename
@@ -80,6 +79,12 @@ class RedisClient:
     async def get_room(self, room_id: str) -> Room | None:
         data = await self.redis.hgetall(RedisKeys.room(room_id))
         return Room.model_validate(data) if data else None
+
+    async def try_start_room(self, room_id: str) -> bool:
+        result = await self._start_quiz_script(
+            keys=[RedisKeys.room(room_id)]
+        )
+        return bool(result)
     
     async def get_questions(self, room_id: str) -> list[Question] | None:
         data = await self.redis.get(RedisKeys.questions(room_id))
@@ -243,32 +248,3 @@ class RedisClient:
                     await handler(room_id, data)
                 except Exception as e:
                     logger.warning(f"Error processing pubsub message: {e}")
-    
-    async def acquire_lock(self, key: str, ttl: int = 60) -> bool:
-        lock_value = str(uuid.uuid4())
-        acquired = await self.redis.set(key, lock_value, nx=True, ex=ttl)
-        if acquired:
-            self._locks[key] = lock_value
-            logger.debug(f"Lock acquired: {key}")
-            return True
-        return False
-    
-    async def release_lock(self, key: str) -> bool:
-        lock_value = self._locks.get(key)
-        if not lock_value:
-            logger.warning(f"Trying to release lock not owned: {key}")
-            return False
-        
-        lua = """
-        if redis.call("GET", KEYS[1]) == ARGV[1] then
-            return redis.call("DEL", KEYS[1])
-        else
-            return 0
-        end
-        """
-        result = await self.redis.eval(lua, 1, key, lock_value)
-        if result:
-            logger.debug(f"Lock released: {key}")
-            return True
-        logger.warning(f"Lock not released, value mismatch: {key}")
-        return False

--- a/backend/game_service/app/services/redis/scripts/start_quiz.lua
+++ b/backend/game_service/app/services/redis/scripts/start_quiz.lua
@@ -1,0 +1,8 @@
+-- KEYS[1] = room:{room_id}
+
+if redis.call("HGET", KEYS[1], "status") ~= "CREATED" then
+    return 0
+end
+
+redis.call("HSET", KEYS[1], "status", "STARTED")
+return 1

--- a/backend/game_service/app/services/room_manager.py
+++ b/backend/game_service/app/services/room_manager.py
@@ -9,8 +9,6 @@ from my_observability import get_logger
 
 logger = get_logger(__name__)
 
-QUIZ_LOCK_TTL = 60
-
 class RoomManager:
     """Coordinates real-time quiz rooms by binding networking, distributed state, and game loops."""
     def __init__(self, redis_client: RedisClient, connection_manager: ConnectionManager) -> None:
@@ -78,29 +76,22 @@ class RoomManager:
         self._ws_to_player[websocket] = player_id
 
     async def start_quiz(self, room_id: str) -> None:
-        """Acquires a distributed lock and spawns a background game loop for the room."""
-        lock_key = f"quiz_lock:{room_id}"
-        acquired = await self._redis.acquire_lock(lock_key, QUIZ_LOCK_TTL)
-        if not acquired:
-            logger.warning("Cannot start quiz: lock already acquired by another instance", room_id=room_id)
+        """Atomically starts the room and spawns its background game loop."""
+        started = await self._redis.try_start_room(room_id)
+        if not started:
+            logger.warning("Room already started or not found", room_id=room_id)
             return
 
-        if room_id in self._quiz_tasks:
-            await self._redis.release_lock(lock_key)
-            logger.warning("Quiz for this room is already running locally", room_id=room_id)
-            return
-
-        engine = QuizEngine(room_id, lock_key, self._redis, self._answer_events)
+        engine = QuizEngine(room_id, self._redis, self._answer_events)
         task = asyncio.create_task(self._wrapped_quiz_runner(room_id, engine))
         self._quiz_tasks[room_id] = task
 
     async def _wrapped_quiz_runner(self, room_id: str, engine: QuizEngine) -> None:
-        """Safely executes the quiz lifecycle and guarantees lock release on termination."""
+        """Safely executes the quiz lifecycle and removes the task on termination."""
         try:
             await engine.run_lifecycle()
         finally:
             self._quiz_tasks.pop(room_id, None)
-            await self._redis.release_lock(engine.lock_key)
 
     async def _cleanup_room_resources(self, room_id: str) -> None:
         """Forcefully halts and unregisters game loops linked to a dead room ID."""

--- a/backend/game_service/tests/services/test_quiz_engine.py
+++ b/backend/game_service/tests/services/test_quiz_engine.py
@@ -24,7 +24,6 @@ def sample_question():
 def engine(mock_redis, events_map):
     return QuizEngine(
         room_id="room_123",
-        lock_key="quiz_lock:room_123",
         redis_client=mock_redis,
         events_map=events_map
     )
@@ -55,7 +54,7 @@ async def test_complete_successful_lifecycle(
         assert mock_wait.call_count == len(sample_question)
         assert mock_sleep.call_count > 0
 
-    assert mock_redis.update_room_status.call_count == 2
+    assert mock_redis.update_room_status.call_count == 1
     assert mock_redis.update_room_progress.call_count == 2
 
     for idx, q in enumerate(sample_question):

--- a/backend/game_service/tests/services/test_redis_client.py
+++ b/backend/game_service/tests/services/test_redis_client.py
@@ -27,6 +27,7 @@ def redis_client():
 
     client.redis.eval.return_value = 1
     client._create_room_script = AsyncMock(return_value=1)
+    client._start_quiz_script = AsyncMock(return_value=1)
 
     return client
 
@@ -203,25 +204,6 @@ async def test_subscribe_rooms(redis_client):
     handler.assert_called_once_with("123", {"type":"msg"})
 
 @pytest.mark.asyncio
-async def test_locks(redis_client):
-    redis_client.redis.set.return_value = True
-    acquired = await redis_client.acquire_lock("key1")
-    assert acquired is True
-
-    redis_client.redis.set.return_value = False
-    acquired = await redis_client.acquire_lock("key1")
-    assert acquired is False
-
-    redis_client._locks["key1"] = "val"
-    redis_client.redis.eval.return_value = 1
-    released = await redis_client.release_lock("key1")
-    assert released is True
-
-    redis_client._locks.pop("key1")
-    released = await redis_client.release_lock("key1")
-    assert released is False
-
-@pytest.mark.asyncio
 async def test_save_answer(redis_client, redis_pipeline):
     room_id = "123"
     q_index = 0
@@ -350,3 +332,19 @@ async def test_get_leaderboard_excludes_internal_room_marker(redis_client, redis
 
     redis_pipeline.hget.assert_called_once_with("room:123:players", "p1")
     assert result == [LeaderboardEntry(player_id="p1", name="John", score=100)]
+
+@pytest.mark.asyncio
+async def test_try_start_room(redis_client):
+    result = await redis_client.try_start_room(
+        room_id="123",
+    )
+
+    assert result is True
+
+    redis_client._start_quiz_script.assert_awaited_once()
+
+    call = redis_client._start_quiz_script.await_args
+
+    assert call.kwargs["keys"] == [
+        "room:123"
+    ]

--- a/backend/game_service/tests/services/test_room_manager.py
+++ b/backend/game_service/tests/services/test_room_manager.py
@@ -4,13 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch, create_autospec
 from fastapi import WebSocket
 from app.services.connection_manager import ConnectionManager
 from app.services.redis.redis_client import RedisClient
-from app.services.room_manager import QUIZ_LOCK_TTL, RoomManager
+from app.services.room_manager import RoomManager
 from app.models.multiplayer import Player
 
 @pytest.fixture
 def mock_redis():
     client = create_autospec(RedisClient, instance=True)
-    client.acquire_lock.return_value = True
+    client.try_start_room.return_value = True
     client.get_players.return_value=[Player(player_id="1", name="Player1"), Player(player_id="2", name="Player2")]
     client.count_answers.return_value=2
     return client
@@ -102,16 +102,16 @@ async def test_disconnect_empty_room_triggers_cleanup(room_manager, mock_websock
     room_manager._cleanup_room_resources.assert_awaited_once_with("room_empty")
 
 @pytest.mark.asyncio
-async def test_start_quiz_lock_already_acquired_on_other_instance(room_manager):
-    room_manager._redis.acquire_lock.return_value = False
+async def test_start_quiz_does_not_start_when_room_cannot_be_transitioned(room_manager):
+    room_manager._redis.try_start_room.return_value = False
 
     await room_manager.start_quiz("room_2")
 
     assert "room_2" not in room_manager._quiz_tasks
-    room_manager._redis.release_lock.assert_not_awaited()
+    room_manager._redis.try_start_room.assert_awaited_once_with("room_2")
 
 @pytest.mark.asyncio
-async def test_start_quiz_already_running_locally_releases_lock(room_manager):
+async def test_start_quiz_does_not_create_duplicate_local_task(room_manager):
     blocker = asyncio.Event()
 
     async def never_ending():
@@ -121,34 +121,31 @@ async def test_start_quiz_already_running_locally_releases_lock(room_manager):
 
     await room_manager.start_quiz("room_3")
 
-    room_manager._redis.release_lock.assert_awaited_once_with("quiz_lock:room_3")
+    room_manager._redis.try_start_room.assert_awaited_once_with("room_3")
 
 @pytest.mark.asyncio
 @patch("app.services.room_manager.QuizEngine")
 async def test_start_quiz_success_spawns_background_task(mock_quiz_engine_cls, room_manager):
     mock_engine = mock_quiz_engine_cls.return_value
-    mock_engine.lock_key = "quiz_lock:room_1"
     mock_engine.run_lifecycle = AsyncMock()
 
     await room_manager.start_quiz("room_1")
 
-    room_manager._redis.acquire_lock.assert_awaited_once_with("quiz_lock:room_1", QUIZ_LOCK_TTL)
+    room_manager._redis.try_start_room.assert_awaited_once_with("room_1")
     mock_quiz_engine_cls.assert_called_once_with(
-        "room_1", "quiz_lock:room_1", room_manager._redis, room_manager._answer_events
+        "room_1", room_manager._redis, room_manager._answer_events
     )
     assert "room_1" in room_manager._quiz_tasks
 
     await asyncio.sleep(0)
 
     mock_engine.run_lifecycle.assert_awaited_once()
-    room_manager._redis.release_lock.assert_awaited_once_with("quiz_lock:room_1")
     assert "room_1" not in room_manager._quiz_tasks
 
 @pytest.mark.asyncio
-async def test_wrapped_quiz_runner_releases_lock_and_removes_task_on_error(room_manager):
+async def test_wrapped_quiz_runner_removes_task_on_error(room_manager):
     room_id = "room_err"
     engine = MagicMock()
-    engine.lock_key = "quiz_lock:room_err"
     engine.run_lifecycle = AsyncMock(side_effect=RuntimeError("boom"))
     room_manager._quiz_tasks[room_id] = asyncio.current_task()
 
@@ -156,7 +153,6 @@ async def test_wrapped_quiz_runner_releases_lock_and_removes_task_on_error(room_
         await room_manager._wrapped_quiz_runner(room_id, engine)
 
     assert room_id not in room_manager._quiz_tasks
-    room_manager._redis.release_lock.assert_awaited_once_with("quiz_lock:room_err")
 
 @pytest.mark.asyncio
 async def test_cleanup_room_resources_cancels_existing_task(room_manager):


### PR DESCRIPTION
- Replace the distributed quiz lock with an atomic Redis Lua transition from CREATED to STARTED.
- Remove lock ownership and release handling from the room manager and quiz engine, while retaining local task tracking for lifecycle cleanup.
- Update the related tests to cover the new room-start behavior and Redis script integration.