### PR TITLE
fix(game_service): validate room status before processing answers

### DIFF
--- a/backend/game_service/app/services/room_ws_service.py
+++ b/backend/game_service/app/services/room_ws_service.py
@@ -108,7 +108,7 @@ class RoomWebSocketService:
                     case StartAction():
                         await self._handle_start(websocket, room_id, session)
                     case AnswerAction():
-                        await self._handle_answer(room_id, session, message)
+                        await self._handle_answer(websocket, room_id, session, message)
             except ValidationError as e:
                 logger.warning(f"Invalid WebSocket payload received in room {room_id}: {e}")
                 await self._send_message(
@@ -148,12 +148,19 @@ class RoomWebSocketService:
         
         await self.manager.start_quiz(room_id)
 
-    async def _handle_answer(self, room_id: str, session: RoomSession, data: AnswerAction) -> None:
+    async def _handle_answer(self, websocket: WebSocket, room_id: str, session: RoomSession, data: AnswerAction) -> None:
         """Saves a player submission and notifies the cluster for real-time early-cutoff logic."""
         room_meta = await self.redis.get_room(room_id)
         if not room_meta:
             return
-        
+
+        if room_meta.status != RoomStatus.STARTED:
+            await self._send_message(
+                websocket,
+                ErrorMessage(code="FORBIDDEN", message="The room has not started yet")
+            )
+            return
+
         question_index = room_meta.current_question_index
 
         await self.redis.save_answer(
@@ -165,8 +172,7 @@ class RoomWebSocketService:
 
         # Broadcast via Pub/Sub to allow any horizontal application instance to process the cutoff check.
         msg = AnswerSubmittedMessage(
-            current_question_index=question_index,
-            player_id=session.player_id,
+            current_question_index=question_index
         )
         await self.redis.publish_room_message(room_id, msg.model_dump())
     

--- a/backend/game_service/tests/services/test_room_ws_service.py
+++ b/backend/game_service/tests/services/test_room_ws_service.py
@@ -92,13 +92,13 @@ async def test_start_as_player_fails(service, mock_websocket):
     })
 
 @pytest.mark.asyncio
-async def test_handle_answer(service, mock_redis):
+async def test_handle_answer(service, mock_redis, mock_websocket):
     mock_redis.get_room.return_value = Room(
         room_id="1",
         owner_id="host-id",
         quiz_id="1",
         current_question_index=2,
-        status=RoomStatus.CREATED
+        status=RoomStatus.STARTED
     )
 
     session = RoomSession(
@@ -107,7 +107,7 @@ async def test_handle_answer(service, mock_redis):
     )
     action = AnswerAction(type="answer", answer="A")
 
-    await service._handle_answer("room1", session, action)
+    await service._handle_answer(mock_websocket, "room1", session, action)
 
     mock_redis.save_answer.assert_called_once_with(
         "room1",


### PR DESCRIPTION
- Ensure room status is STARTED before allowing players to submit answers in _handle_answer, returning a FORBIDDEN error otherwise.
- Pass the websocket instance to _handle_answer to support error messaging over the socket.
- Remove redundant player_id from AnswerSubmittedMessage payload.