### PR TITLE
fix(game_service): prevent duplicate answer submissions using atomic …

### DIFF
--- a/backend/game_service/app/services/redis/redis_client.py
+++ b/backend/game_service/app/services/redis/redis_client.py
@@ -144,18 +144,20 @@ class RedisClient:
             question_index: int,
             player_id: str,
             answer: str
-    ) -> None:
+    ) -> bool:
         answers_key = RedisKeys.answers(room_id, question_index)
         room_answer = RoomAnswer(answer=answer, timestamp=time.time())
 
         async with self.redis.pipeline(transaction=True) as pipe:
-            pipe.hset(
+            pipe.hsetnx(
                 answers_key,
                 player_id,
                 room_answer.model_dump_json()
             )
             pipe.expire(answers_key, 300, nx=True)
-            await pipe.execute()
+            results = await pipe.execute()
+
+        return bool(results[0])
 
     async def get_answers(self, room_id: str, question_index: int) -> dict[str, RoomAnswer]:
         raw =  await self.redis.hgetall(RedisKeys.answers(room_id, question_index))

--- a/backend/game_service/app/services/room_ws_service.py
+++ b/backend/game_service/app/services/room_ws_service.py
@@ -163,12 +163,22 @@ class RoomWebSocketService:
 
         question_index = room_meta.current_question_index
 
-        await self.redis.save_answer(
+        saved = await self.redis.save_answer(
             room_id,
             question_index,
             session.player_id,
             data.answer
         )
+
+        if not saved:
+            await self._send_message(
+                websocket,
+                ErrorMessage(
+                    code="ANSWER_ALREADY_SUBMITTED",
+                    message="You have already submitted an answer for this question"
+                )
+            )
+            return
 
         # Broadcast via Pub/Sub to allow any horizontal application instance to process the cutoff check.
         msg = AnswerSubmittedMessage(

--- a/backend/game_service/tests/services/test_redis_client.py
+++ b/backend/game_service/tests/services/test_redis_client.py
@@ -216,7 +216,7 @@ async def test_save_answer(redis_client, redis_pipeline):
 
     redis_client.redis.pipeline.assert_called_once_with(transaction=True)
 
-    assert redis_pipeline.hset.call_args == call(
+    assert redis_pipeline.hsetnx.call_args == call(
         "room:123:answers:0",
         "player_1",
         RoomAnswer(answer=answer, timestamp=fixed_time).model_dump_json(),

--- a/backend/game_service/tests/services/test_room_ws_service.py
+++ b/backend/game_service/tests/services/test_room_ws_service.py
@@ -139,3 +139,37 @@ async def test_room_already_started(service, mock_websocket, mock_redis):
         await service._initialize_session(mock_websocket, "room1")
 
     mock_websocket.close.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_handle_answer_when_already_submitted_sends_error_message(service, mock_redis, mock_websocket):
+    mock_redis.get_room.return_value = Room(
+        room_id="room1",
+        owner_id="host-id",
+        quiz_id="1",
+        current_question_index=0,
+        status=RoomStatus.STARTED
+    )
+    mock_redis.save_answer.return_value=False
+
+    session = RoomSession(
+        player_id="p1",
+        role="player"
+    )
+    action = AnswerAction(type="answer", answer="A")
+
+    await service._handle_answer(mock_websocket, "room1", session, action)
+
+    mock_redis.save_answer.assert_called_once_with(
+        "room1",
+        0,
+        "p1",
+        "A"
+    )
+
+    mock_websocket.send_json.assert_called_once_with({
+        "type": "error",
+        "code": "ANSWER_ALREADY_SUBMITTED",
+        "message": "You have already submitted an answer for this question"
+    })
+
+    mock_redis.publish_room_message.assert_not_called()

--- a/frontend/src/hooks/useRoomLogic.ts
+++ b/frontend/src/hooks/useRoomLogic.ts
@@ -109,6 +109,10 @@ export function useRoomLogic() {
             onError: (code, message) => {
                 alert(message);
 
+                if (code === "ANSWER_ALREADY_SUBMITTED" || code === "FORBIDDEN") {
+                    setSelectedAnswer(null);
+                }
+
                 if (code == "ROOM_NOT_FOUND" || code == "ROOM_ALREADY_STARTED") {
                     setRedirect("/");
                 }


### PR DESCRIPTION
…redis check

- Update RedisClient.save_answer to use HSETNX to atomically reject duplicate submissions for the same question.
- Update _handle_answer in RoomWebSocketService to handle duplicate answer attempts and return an ANSWER_ALREADY_SUBMITTED error to the client.
- Reset selected answer in the frontend hook on error to keep UI state in sync with backend validation.
- Add unit test coverage for duplicate answer submission scenario.