### PR TITLE
fix(game_serivce): use Redis as single source of truth for timestamps

### DIFF
--- a/backend/game_service/app/services/quiz_engine.py
+++ b/backend/game_service/app/services/quiz_engine.py
@@ -48,12 +48,10 @@ class QuizEngine:
                     msg_question.model_dump()
                 )
 
-                question_start = time.time()
-
                 # Suspend execution until all answers are submitted or the timeout expires.
                 await self._wait_for_answers_or_timeout(idx)
 
-                await self._process_answers(question, idx, question_start)
+                await self._process_answers(question, idx)
                 await asyncio.sleep(ANSWER_REVEAL_DURATION)
 
                 await self._publish_leaderboard(final=is_last)
@@ -101,9 +99,10 @@ class QuizEngine:
 
         self._events_map.pop(event_key, None)
 
-    async def _process_answers(self, question: Question, question_index: int, start_time: float) -> None:
+    async def _process_answers(self, question: Question, question_index: int) -> None:
         """Evaluates answers from Redis and increments scores with time-based decay logic."""
         answers = await self._redis.get_answers(self.room_id, question_index)
+        start_time = await self._redis.get_question_start_timestamp(self.room_id)
 
         msg_answer = AnswerResultMessage(correct_answer=question.correct_option)
         await self._redis.publish_room_message(

--- a/backend/game_service/app/services/redis/redis_client.py
+++ b/backend/game_service/app/services/redis/redis_client.py
@@ -1,6 +1,5 @@
 import redis.asyncio as redis
 import json
-import time
 from app.schemas.multiplayer import Room, RoomAnswer, Question, RoomStatus
 from app.models.multiplayer import Player, LeaderboardEntry
 from app.core.config import config
@@ -26,6 +25,10 @@ class RedisClient:
         script_path = SCRIPTS_DIR / filename
         script_content = script_path.read_text(encoding="utf-8")
         return self.redis.register_script(script_content)
+
+    async def _get_redis_timestamp(self) -> float:
+        seconds, microseconds = await self.redis.time()
+        return seconds + (microseconds / 1_000_000)
 
     async def create_room(
             self,
@@ -61,9 +64,14 @@ class RedisClient:
             room_id: str,
             index: int,
     ) -> None:
+        start_timestamp = await self._get_redis_timestamp()
+
         await self.redis.hset(
             RedisKeys.room(room_id),
-            mapping={"current_question_index": index}
+            mapping={
+                "current_question_index": index,
+                "question_start_timestamp": start_timestamp
+            }
         )
 
     async def update_room_status(
@@ -79,6 +87,10 @@ class RedisClient:
     async def get_room(self, room_id: str) -> Room | None:
         data = await self.redis.hgetall(RedisKeys.room(room_id))
         return Room.model_validate(data) if data else None
+
+    async def get_question_start_timestamp(self, room_id: str) -> float | None:
+        val = await self.redis.hget(RedisKeys.room(room_id), "question_start_timestamp")
+        return float(val) if val else None
 
     async def try_start_room(self, room_id: str) -> bool:
         result = await self._start_quiz_script(
@@ -146,7 +158,8 @@ class RedisClient:
             answer: str
     ) -> bool:
         answers_key = RedisKeys.answers(room_id, question_index)
-        room_answer = RoomAnswer(answer=answer, timestamp=time.time())
+        current_timestamp = await self._get_redis_timestamp()
+        room_answer = RoomAnswer(answer=answer, timestamp=current_timestamp)
 
         async with self.redis.pipeline(transaction=True) as pipe:
             pipe.hsetnx(

--- a/backend/game_service/tests/services/test_quiz_engine.py
+++ b/backend/game_service/tests/services/test_quiz_engine.py
@@ -72,15 +72,16 @@ async def test_process_answers_with_linear_score_decay(engine, mock_redis):
     question = Question(id="q1", question_text="Question 1", options=["A", "B", "C", "D"], correct_option="A")
     question_idx = 0
 
+    mock_redis.get_question_start_timestamp.return_value = 100.0
     mock_redis.get_answers.return_value = {
         "p1": RoomAnswer(answer="A", timestamp=100.0),
         "p2": RoomAnswer(answer="A", timestamp=114.0),
         "p3": RoomAnswer(answer="B", timestamp=101.0)
     }
 
-    with patch("time.time", return_value=100.0):
-        await engine._process_answers(question, question_idx, 100.0)
+    await engine._process_answers(question, question_idx)
 
+    mock_redis.get_question_start_timestamp.assert_awaited_once_with(engine.room_id)
     mock_redis.increment_score.assert_any_call(engine.room_id, "p1", 1000)
     mock_redis.increment_score.assert_any_call(engine.room_id, "p2", 200)
 

--- a/backend/game_service/tests/services/test_redis_client.py
+++ b/backend/game_service/tests/services/test_redis_client.py
@@ -1,6 +1,6 @@
 import pytest
 import json
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, call
 from app.services.redis.redis_client import RedisClient
 from app.schemas.multiplayer import Question, RoomAnswer
 from app.models.multiplayer import Player, LeaderboardEntry
@@ -28,6 +28,7 @@ def redis_client():
     client.redis.eval.return_value = 1
     client._create_room_script = AsyncMock(return_value=1)
     client._start_quiz_script = AsyncMock(return_value=1)
+    client.redis.time = AsyncMock(return_value=(1711000000, 0))
 
     return client
 
@@ -210,16 +211,16 @@ async def test_save_answer(redis_client, redis_pipeline):
     player_id = "player_1"
     answer = "A"
     
-    fixed_time = 1711000000.0
-    with patch("time.time", return_value=fixed_time):
-        await redis_client.save_answer(room_id, q_index, player_id, answer)
+    expected_timestamp = 1711000000.0
+    await redis_client.save_answer(room_id, q_index, player_id, answer)
 
+    redis_client.redis.time.assert_awaited_once()
     redis_client.redis.pipeline.assert_called_once_with(transaction=True)
 
     assert redis_pipeline.hsetnx.call_args == call(
         "room:123:answers:0",
         "player_1",
-        RoomAnswer(answer=answer, timestamp=fixed_time).model_dump_json(),
+        RoomAnswer(answer=answer, timestamp=expected_timestamp).model_dump_json(),
     )
 
     redis_pipeline.expire.assert_called_once_with("room:123:answers:0", 300, nx=True)


### PR DESCRIPTION
- Store question start timestamp directly in Redis room hash during progression.
- Fetch room question start timestamp when processing answers in QuizEngine.
- Fetch answer submission timestamps using Redis server time instead of local machine clock.
- Update unit tests for process_answers and save_answer to mock redis.time().